### PR TITLE
Fix compatibility with Mojolicious 8.23

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess/CGroup.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/CGroup.pm
@@ -33,8 +33,8 @@ sub from {
 
 sub _cgroup {
   path($_[0]->parent ?
-      path($_[0]->_vfs, $_[0]->name, $_[0]->parent)
-    : path($_[0]->_vfs, $_[0]->name));
+      path($_[0]->_vfs, $_[0]->name // '', $_[0]->parent)
+    : path($_[0]->_vfs, $_[0]->name // ''));
 }
 
 sub create { $_[0]->_cgroup->make_path unless -d $_[0]->_cgroup; $_[0] }

--- a/lib/Mojo/IOLoop/ReadWriteProcess/CGroup/v1.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/CGroup/v1.pm
@@ -29,8 +29,8 @@ has controller => '';
 sub _cgroup {
   path($_[0]->parent
     ?
-      path($_[0]->_vfs, $_[0]->controller, $_[0]->name, $_[0]->parent)
-    : path($_[0]->_vfs, $_[0]->controller, $_[0]->name));
+      path($_[0]->_vfs, $_[0]->controller // '', $_[0]->name // '', $_[0]->parent)
+    : path($_[0]->_vfs, $_[0]->controller // '', $_[0]->name // ''));
 }
 
 sub child {


### PR DESCRIPTION
This is a fix for #4. In Mojolicious 8.23 we no longer allow `undef` values in `Mojo::File` to prevent common accidents when deleting files/directories (since there is no sensible use case where you actually want `undef` in your path).