### PR TITLE
In "stop" sleep only after sending the first signal to speedup termination

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -516,7 +516,6 @@ sub stop {
         . ") to kill process: "
         . $self->pid)
       if DEBUG;
-    sleep $self->sleeptime_during_kill if $self->sleeptime_during_kill;
     $self->session->_protect(
       sub {
         local $?;
@@ -525,6 +524,7 @@ sub stop {
         $self->_status($?) if $ret == $self->process_id;
       });
     $attempt++;
+    sleep $self->sleeptime_during_kill if $self->sleeptime_during_kill;
   }
 
   sleep $self->kill_sleeptime if $self->kill_sleeptime;

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -76,6 +76,7 @@ subtest 'process is_running()' => sub {
     });
 
   $p->start();
+  sleep 1;    # Give chance to print some output
   $p->stop();
 
   close(CHILD);


### PR DESCRIPTION
By default the sleep time between sending term/kill signals is 1s
meaning that previously the termination of each process took *at least*
1s which adds up in multi-process applications. There should be no need
to wait until we send out the first signal to the process to stop.