### PR TITLE
Fix sporadic test failures introduced by fb9bc63

### DIFF
--- a/t/01_run.t
+++ b/t/01_run.t
@@ -97,6 +97,7 @@ subtest 'process is_running()' => sub {
     });
   $p->restart()->restart()->restart();
   is $p->is_running, 1, "Process now is running";
+  sleep 1;    # Give chance to print some output
   $p->stop();
   close(CHILD);
   @output = <PARENT>;
@@ -116,6 +117,7 @@ subtest 'process is_running()' => sub {
   }
 
   is $p->is_running, 1, "Process now is running";
+  sleep 1;    # Give chance to print some output
   $p->stop();
   close(CHILD);
   @output = <PARENT>;


### PR DESCRIPTION
As fb9bc63 deleted the internal timeout within the "stop()" method some
tests need to be adjusted to prevent sporadic test failures same as
already done in fb9bc63 for another test. The fix is done using the same
approach, i.e. adding a `sleep 1` to give a chance to the subprocesses
to print some output.

Verified with 10/10 successful local test runs.