### PR TITLE
Fix flaky test failures in 01_run.t; improve tests

### DIFF
--- a/t/01_run.t
+++ b/t/01_run.t
@@ -21,7 +21,7 @@ subtest process => sub {
     local *STDERR = $handle;
     $c->_diag("FOOTEST");
   };
-  like $buffer, qr/>> main::__ANON__\(\): FOOTEST/,
+  like $buffer, qr/>> main::__ANON__(.*\])*\(\): FOOTEST/,
     "diag() correct output format";
 };
 

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -197,7 +197,6 @@ subtest 'process execute()' => sub {
   );
   $p2->start();
   is $p2->getline, undef, "pipes are correctly disabled";
-  is $p2->getline, undef, "pipes are correctly disabled";
   $p2->stop();
   is !!$p2->_status, 1,
     'take exit status even with set_pipes = 0 (we killed it)';

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -223,7 +223,7 @@ killed'
   $p->max_kill_attempts(5);
   $p->stop;
   $p->wait;
-  is $p->is_running, 0, 'process is shutten down';
+  is $p->is_running, 0, 'process is shut down';
   is $p->errored,    1, 'Process died and errored';
 
 
@@ -237,7 +237,7 @@ killed'
   sleep 4;
 
   is $p->is_running, 0,
-    'process is shutten down by kill signal when "blocking_stop => 1"';
+    'process is shut down by kill signal when "blocking_stop => 1"';
 
   my $pidfile = tempfile;
   $p = Mojo::IOLoop::ReadWriteProcess->new(

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -210,11 +210,9 @@ subtest 'process execute()' => sub {
   $p->start();
   $p->stop();
   is $p->is_running, 1, 'process is still running';
-  like(
-    ${(@{$p->error})[0]}, qr/Could not kill process/,
-    'Error is not empty if process could not be
-killed'
-  );
+  my $err = ${(@{$p->error})[0]};
+  my $exp = qr/Could not kill process/;
+  like $err, $exp , 'Error is not empty if process could not be killed';
   $p->max_kill_attempts(50);
   $p->blocking_stop(0);
   $p->stop();

--- a/t/data/process_check.sh
+++ b/t/data/process_check.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+cleanup() {
+    echo "TEST exiting"
+}
+
+trap cleanup EXIT
+
 (>&2 echo "TEST error print")
 echo "TEST normal print"
 


### PR DESCRIPTION
* t: Fix flaky test failures in 01_run.t after removing timeout in "stop()"
* t: Generalize test for 'diag' to also accept format from perl debugger
* t: Prevent line wrap in test explanation string to prevent confusion
* t: Fix incorrect english spelling in explanation string
* t: Delete duplicate test line 'pipes are correctly disabled'