### PR TITLE
Improve stopping

### DIFF
--- a/t/01_run.t
+++ b/t/01_run.t
@@ -37,7 +37,10 @@ subtest 'process basic functions' => sub {
   like $@, qr/Nothing to do/,
     "Process with no code nor execute command, will fail";
 
-  $p = Mojo::IOLoop::ReadWriteProcess->new();
+  $p = Mojo::IOLoop::ReadWriteProcess->new(
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01
+  );
   eval { $p->_fork(); };
   ok $@, "Error expected";
   like $@, qr/Can't spawn child without code/, "_fork() with no code will fail";
@@ -47,7 +50,9 @@ subtest 'process basic functions' => sub {
     pipe(PARENT, CHILD);
 
     my $p = Mojo::IOLoop::ReadWriteProcess->new(
-      code => sub {
+      kill_sleeptime        => 0.01,
+      sleeptime_during_kill => 0.01,
+      code                  => sub {
         close(PARENT);
         open STDERR, ">&", \*CHILD or die $!;
         print STDERR "FOOBARFTW\n" while 1;
@@ -67,7 +72,9 @@ subtest 'process is_running()' => sub {
   pipe(PARENT, CHILD);
 
   my $p = Mojo::IOLoop::ReadWriteProcess->new(
-    code => sub {
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    code                  => sub {
       close(PARENT);
       open STDERR, ">&", \*CHILD or die $!;
       print STDERR "FOOBARFTW\n";
@@ -133,9 +140,12 @@ subtest 'process execute()' => sub {
 "You do not seem to have $test_script_sigtrap. The script is required to run the test"
     unless -e $test_script_sigtrap;
   use Mojo::IOLoop::ReadWriteProcess;
-  my $p = Mojo::IOLoop::ReadWriteProcess->new(execute => $test_script)->start();
-  is $p->getline, "TEST normal print\n", 'Get right output from stdout';
-  is $p->err_getline, "TEST error print\n", 'Get right output from stderr';
+  my $p = Mojo::IOLoop::ReadWriteProcess->new(
+    sleeptime_during_kill => 0.1,
+    execute               => $test_script
+  )->start();
+  is $p->getline,     "TEST normal print\n", 'Get right output from stdout';
+  is $p->err_getline, "TEST error print\n",  'Get right output from stderr';
   is $p->is_running, 1, 'process is still waiting for our input';
   $p->write("FOOBAR");
   is $p->read, "you entered FOOBAR\n",
@@ -144,8 +154,10 @@ subtest 'process execute()' => sub {
   is $p->is_running, 0, 'process is not running anymore';
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    execute => $test_script,
-    args    => [
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    execute               => $test_script,
+    args                  => [
       qw(FOO
         BAZ)
     ])->start();
@@ -160,10 +172,12 @@ subtest 'process execute()' => sub {
   is $p->getline,     "FOO BAZ\n", 'process received extra arguments';
   is $p->exit_status, 100,         'able to retrieve function return';
 
-  $p = Mojo::IOLoop::ReadWriteProcess->new(execute => $test_script)
-    ->args([qw(FOO BAZ)])->start();
-  is $p->stdout, "TEST normal print\n", 'Get right output from stdout';
-  is $p->err_getline, "TEST error print\n", 'Get right output from stderr';
+  $p = Mojo::IOLoop::ReadWriteProcess->new(
+    sleeptime_during_kill => 0.1,
+    execute               => $test_script
+  )->args([qw(FOO BAZ)])->start();
+  is $p->stdout,      "TEST normal print\n", 'Get right output from stdout';
+  is $p->err_getline, "TEST error print\n",  'Get right output from stderr';
   is $p->is_running, 1, 'process is still waiting for our input';
   $p->write("FOOBAR");
   is $p->getline, "you entered FOOBAR\n",
@@ -174,8 +188,10 @@ subtest 'process execute()' => sub {
   is $p->exit_status, 100,         'able to retrieve function return';
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    separate_err => 0,
-    execute      => $test_script
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    separate_err          => 0,
+    execute               => $test_script
   );
   $p->start();
   is $p->is_running, 1, 'process is still running';
@@ -186,9 +202,11 @@ subtest 'process execute()' => sub {
     'Still able to get stdout output, always in getline()';
 
   my $p2 = Mojo::IOLoop::ReadWriteProcess->new(
-    separate_err => 0,
-    execute      => $test_script,
-    set_pipes    => 0
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    separate_err          => 0,
+    execute               => $test_script,
+    set_pipes             => 0
   );
   $p2->start();
   is $p2->getline, undef, "pipes are correctly disabled";
@@ -197,17 +215,19 @@ subtest 'process execute()' => sub {
     'take exit status even with set_pipes = 0 (we killed it)';
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    verbose           => 1,
-    separate_err      => 0,
-    execute           => $test_script_sigtrap,
-    max_kill_attempts => -4
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    verbose               => 1,
+    separate_err          => 0,
+    execute               => $test_script_sigtrap,
+    max_kill_attempts     => -4,
   );    # ;)
   $p->start();
   $p->stop();
   is $p->is_running, 1, 'process is still running';
   my $err = ${(@{$p->error})[0]};
   my $exp = qr/Could not kill process/;
-  like $err, $exp , 'Error is not empty if process could not be killed';
+  like $err, $exp, 'Error is not empty if process could not be killed';
   $p->max_kill_attempts(50);
   $p->blocking_stop(0);
   $p->stop();
@@ -221,11 +241,13 @@ subtest 'process execute()' => sub {
 
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    verbose           => 1,
-    separate_err      => 0,
-    blocking_stop     => 1,
-    execute           => $test_script,
-    max_kill_attempts => -1              # ;)
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    verbose               => 1,
+    separate_err          => 0,
+    blocking_stop         => 1,
+    execute               => $test_script,
+    max_kill_attempts     => -1              # ;)
   )->start()->stop();
 
   is $p->is_running, 0,
@@ -233,12 +255,14 @@ subtest 'process execute()' => sub {
 
   my $pidfile = tempfile;
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    verbose           => 1,
-    separate_err      => 0,
-    blocking_stop     => 1,
-    execute           => $test_script,
-    max_kill_attempts => -1,             # ;)
-    pidfile           => $pidfile
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    verbose               => 1,
+    separate_err          => 0,
+    blocking_stop         => 1,
+    execute               => $test_script,
+    max_kill_attempts     => -1,             # ;)
+    pidfile               => $pidfile
   )->start();
   my $pid = path($pidfile)->slurp();
   is -e $pidfile, 1, 'Pidfile is there!';
@@ -248,11 +272,13 @@ subtest 'process execute()' => sub {
 
   $pidfile = tempfile;
   $p       = Mojo::IOLoop::ReadWriteProcess->new(
-    verbose           => 1,
-    separate_err      => 0,
-    blocking_stop     => 1,
-    execute           => $test_script,
-    max_kill_attempts => -1,             # ;)
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    verbose               => 1,
+    separate_err          => 0,
+    blocking_stop         => 1,
+    execute               => $test_script,
+    max_kill_attempts     => -1,             # ;)
   )->start();
   $p->write_pidfile($pidfile);
   $pid = path($pidfile)->slurp();
@@ -262,11 +288,13 @@ subtest 'process execute()' => sub {
   is -e $pidfile, undef, 'Pidfile got removed after stop()';
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    verbose           => 1,
-    separate_err      => 0,
-    blocking_stop     => 1,
-    execute           => $test_script,
-    max_kill_attempts => -1,             # ;)
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    verbose               => 1,
+    separate_err          => 0,
+    blocking_stop         => 1,
+    execute               => $test_script,
+    max_kill_attempts     => -1,             # ;)
   )->start();
   is $p->write_pidfile(), undef, "No filename given to write_pidfile";
   $p->stop();
@@ -276,7 +304,9 @@ subtest 'process code()' => sub {
   use Mojo::IOLoop::ReadWriteProcess;
   use IO::Select;
   my $p = Mojo::IOLoop::ReadWriteProcess->new(
-    code => sub {
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    code                  => sub {
       my ($self)        = shift;
       my $parent_output = $self->channel_out;
       my $parent_input  = $self->channel_in;
@@ -329,8 +359,10 @@ subtest 'process code()' => sub {
   is $p->is_running, 0, 'process is not running';
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    separate_err => 0,
-    code         => sub {
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    separate_err          => 0,
+    code                  => sub {
       my ($self)        = shift;
       my $parent_output = $self->channel_out;
       my $parent_input  = $self->channel_in;
@@ -345,7 +377,8 @@ subtest 'process code()' => sub {
   is $p->is_running,    0,   'process is not running';
   is $p->return_status, 256, 'right return code';
 
-  $p = Mojo::IOLoop::ReadWriteProcess->new(sub { die "Fatal error"; });
+  $p = Mojo::IOLoop::ReadWriteProcess->new(sub { die "Fatal error"; },
+    sleeptime_during_kill => 0.1);
   my $event_fired = 0;
   $p->on(
     process_error => sub {
@@ -361,16 +394,24 @@ subtest 'process code()' => sub {
   like(${(@{$p->error})[0]}, qr/Fatal error/, 'right error');
   is $event_fired, 1, 'error event fired';
 
-  $p = Mojo::IOLoop::ReadWriteProcess->new(sub { return 42 },
-    internal_pipes => 0);
+  $p = Mojo::IOLoop::ReadWriteProcess->new(
+    sub { return 42 },
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    internal_pipes        => 0
+  );
   $p->start();
   $p->wait_stop();
   is $p->is_running, 0, 'process is not running';
   is $p->return_status, undef,
     'process did not return nothing when internal_pipes are disabled';
 
-  $p = Mojo::IOLoop::ReadWriteProcess->new(sub { die "Bah" },
-    internal_pipes => 0);
+  $p = Mojo::IOLoop::ReadWriteProcess->new(
+    sub { die "Bah" },
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    internal_pipes        => 0
+  );
   $p->start();
   $p->wait_stop();
   is $p->is_running, 0, 'process is not running';
@@ -379,9 +420,11 @@ subtest 'process code()' => sub {
 # XXX: flaky test temporarly skip it. is !!$p->exit_status, 1, 'Exit status is there';
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    separate_err => 0,
-    set_pipes    => 0,
-    code         => sub {
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    separate_err          => 0,
+    set_pipes             => 0,
+    code                  => sub {
       print "TEST normal print\n";
       print STDERR "TEST error print\n";
       return "256";
@@ -392,17 +435,21 @@ subtest 'process code()' => sub {
   is $p->return_status, 256, "grab exit_status even if no pipes are set";
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    separate_err => 0,
-    set_pipes    => 1,
-    code         => sub {
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    separate_err          => 0,
+    set_pipes             => 1,
+    code                  => sub {
       exit 100;
     })->start();
   $p->wait_stop();
   is $p->exit_status, 100, "grab exit_status even if no pipes are set";
 
   $p = Mojo::IOLoop::ReadWriteProcess->new(
-    separate_err => 0,
-    code         => sub {
+    kill_sleeptime        => 0.01,
+    sleeptime_during_kill => 0.01,
+    separate_err          => 0,
+    code                  => sub {
       print STDERR "TEST error print\n" for (1 .. 6);
       my $a = <STDIN>;
     })->start();
@@ -425,7 +472,11 @@ subtest process_debug => sub {
     local *STDERR = $handle;
     delete $INC{'Mojo/IOLoop/ReadWriteProcess.pm'};
     eval "no warnings; require Mojo::IOLoop::ReadWriteProcess";    ## no critic
-    Mojo::IOLoop::ReadWriteProcess->new(sub { 1; })->start()->stop();
+    Mojo::IOLoop::ReadWriteProcess->new(
+      code                  => sub { 1; },
+      kill_sleeptime        => 0.01,
+      sleeptime_during_kill => 0.01
+    )->start()->stop();
   }
 
   like $buffer, qr/Fork: \{/,
@@ -439,7 +490,10 @@ process';
     delete $INC{'Mojo/IOLoop/ReadWriteProcess.pm'};
     eval "no warnings; require Mojo::IOLoop::ReadWriteProcess";    ## no critic
     Mojo::IOLoop::ReadWriteProcess->new(
-      execute => "$FindBin::Bin/data/process_check.sh")->start()->stop();
+      execute               => "$FindBin::Bin/data/process_check.sh",
+      kill_sleeptime        => 0.01,
+      sleeptime_during_kill => 0.01,
+    )->start()->stop();
   }
 
   like $buffer, qr/Execute: .*process_check.sh/,

--- a/t/data/simple_fork.pl
+++ b/t/data/simple_fork.pl
@@ -1,0 +1,15 @@
+use warnings;
+use strict;
+
+my $pid1 = fork();
+if ($pid1 == 0) {
+  print "fork 1\n";
+  sleep 1000;
+}
+my $pid2 = fork();
+if ($pid2 == 0) {
+  print "fork 2\n";
+  sleep 1000;
+}
+waitpid $pid1, 0;
+waitpid $pid2, 0;


### PR DESCRIPTION
* See particular commit messages
* See https://progress.opensuse.org/issues/67342 for the full story
    * TL;DR: We want to allow ffmpeg to finalize its video.
        * For that we need to prevent spamming SIGTERM signals on it without introducing long sleep times.
        * We also need to be able to stop the full process group and wait for the termination of the full process group to know when ffmpeg has finalized the video.