### PR TITLE
Avoid executing "blocking stop" code when process has already terminated

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -535,6 +535,7 @@ sub stop {
       $timeout -= $sleep_time;
     }
   }
+  return $self->_shutdown if defined $self->_status;
 
   sleep $self->kill_sleeptime if $self->kill_sleeptime;
 

--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -396,7 +396,6 @@ sub exit_status {
 }
 
 sub restart {
-  $_[0]->{_status} = undef;
   $_[0]->is_running ? $_[0]->stop->start : $_[0]->start;
 }
 sub is_running { $_[0]->process_id ? kill 0 => $_[0]->process_id : 0; }
@@ -473,6 +472,7 @@ sub start {
     : ();
 
   $self->session->enable_subreaper if $self->subreaper;
+  $self->_status(undef);
 
   if ($self->code) {
     $self->_fork($self->code, @args);
@@ -547,13 +547,13 @@ sub stop {
     $self->send_signal($self->_default_blocking_signal, $pid);
     $ret = waitpid($pid, 0);
     $self->_status($?) if $ret == $pid || $ret == -1;
+    return $self->_shutdown;
   }
   else {
     $self->_diag("Could not kill process id: $pid") if DEBUG;
     $self->_new_err('Could not kill process');
   }
-
-  return $self->_shutdown;
+  return $self;
 }
 
 sub _shutdown {

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -225,6 +225,7 @@ subtest 'process execute()' => sub {
   $p->start();
   $p->stop();
   is $p->is_running, 1, 'process is still running';
+  is $p->_status, undef, 'no status yet';
   my $err = ${(@{$p->error})[0]};
   my $exp = qr/Could not kill process/;
   like $err, $exp, 'Error is not empty if process could not be killed';


### PR DESCRIPTION
This saves measurably time, e.g. the os-autoinst test `t/18-qemu-options.t`
needs 28 seconds to execute on my system without this change and 11 seconds
with this change.

See https://progress.opensuse.org/issues/71110 for the motivation.