### PR TITLE
Match on 'armv7l' as well as 'arm' for prctl detection

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
@@ -155,7 +155,7 @@ sub _get_prctl_syscall {
     : ($machine eq "ppc" || $machine eq "ppc64le") ? 171
     : $machine eq "ia64"                           ? 1170
     : $machine eq "alpha"                          ? 348
-    : $machine eq "arm"                            ? 0x900000 + 172
+    : ($machine eq "arm" || $machine eq "armv7l")  ? 0x900000 + 172
     : $machine eq "avr32"                          ? 148
     : $machine eq "mips"                           ? 4000 + 192
     : $machine eq "mips64"                         ? 5000 + 153


### PR DESCRIPTION
...as this is what the uname call gives on Fedora's 32-bit ARM
builders, at least. Not matching it ultimately leads to the
os-autoinst test suite failing on 32-bit ARM package builds.

Signed-off-by: Adam Williamson <awilliam@redhat.com>