### PR TITLE
Fix _getlines() don't add extra '\n' string in scalar context

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -424,7 +424,7 @@ sub _getline {
 
 sub _getlines {
   return unless IO::Select->new($_[0])->can_read(10);
-  wantarray ? shift->getlines : join '\n', @{[shift->getlines]};
+  wantarray ? shift->getlines : join '', @{[shift->getlines]};
 }
 
 # Write to the controlled-process STDIN


### PR DESCRIPTION
This fix all methods which use _getlines() underneath, e.g.
read_all_stdout().
In scalar context, this function return a join() version of
`IO::Handle::getlines()`. With this fix, we avoid the extra added '\n' string.