### PR TITLE
Fix race of SIG{CHLD} handler setup

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -221,6 +221,8 @@ sub _fork {
   # Separated handles that could be used for internal comunication.
   my ($channel_in, $channel_out);
 
+  $self->session->enable;
+
   if ($self->set_pipes) {
     $input_pipe = IO::Pipe->new()
       or $self->_new_err('Failed creating input pipe');
@@ -336,8 +338,6 @@ sub _fork {
     $self->_exit($@ // $!);
   }
   $self->process_id($pid);
-
-  $self->session->enable;
 
   return $self unless $self->set_pipes();
 


### PR DESCRIPTION
The `SIG{CHLD}` must be setup before we fork().
Otherwise there is a small risk of a race, that the fork already exited
before the SIG{CHLD} was set and we end up in a `$p->is_running()`
endless loop.

It is easy to reproduce, just place a `sleep 1` before this `enable()` call here https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/blob/master/lib/Mojo/IOLoop/ReadWriteProcess.pm#L340