### PR TITLE
Session: Do not set SIG{CHLD} handler twice

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
@@ -43,6 +43,7 @@ sub _protect {
 }
 
 sub enable {
+  return if $singleton->handler();
   $singleton->handler($SIG{CHLD});
   $singleton->_protect(
     sub {


### PR DESCRIPTION
If we set the child handler once, we store the old handler in our member
`handler`. But this wasn't guarded, so if someone actually creates
two processes within one `session` object, we overwrite the old handler.