### PR TITLE
Fix `args` processing

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -645,7 +645,7 @@ Mojo::IOLoop::ReadWriteProcess - Execute external programs or internal code bloc
     my $output = process( sub { print "Hello\n" } )->start()->wait_stop->getline;
 
     # Handles seamelessy also external processes:
-    my $process = process(execute=> '/path/to/bin' )->args(qw(foo bar baz));
+    my $process = process(execute=> '/path/to/bin' )->args([qw(foo bar baz)]);
     $process->start();
     my $line_output = $process->getline();
     my $pid = $process->pid();
@@ -798,7 +798,7 @@ You do not need to specify C<code>, it is implied if no arguments is given.
 
     # The process will print "Hello User"
 
-Array or arrayref of options to pass by to the external binary or the code block.
+Arguments pass to the external binary or the code block. Use arrayref to pass many.
 
 =head2 blocking_stop
 

--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -43,13 +43,12 @@ has [qw(blocking_stop serialize quirkiness total_sleeptime_during_kill)] => 0;
 has [
   qw(execute code process_id pidfile return_status),
   qw(channel_in channel_out write_stream read_stream error_stream),
-  qw(_internal_err _internal_return _status)
+  qw(_internal_err _internal_return _status args)
 ];
 
 has max_kill_attempts => 5;
 has kill_whole_group  => 0;
 
-has args  => sub { [] };
 has error => sub { Mojo::Collection->new };
 
 has ioloop  => sub { Mojo::IOLoop->singleton };
@@ -465,7 +464,7 @@ sub start {
   die "Nothing to do" unless !!$self->execute || !!$self->code;
 
   my @args
-    = $self->args
+    = defined($self->args)
     ? ref($self->args) eq "ARRAY"
       ? @{$self->args}
       : $self->args

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -540,4 +540,24 @@ process';
 'setting MOJO_PROCESS_DEBUG to 1 enables debug mode when executing external process';
 };
 
+subtest 'process_args' => sub {
+  use Mojo::IOLoop::ReadWriteProcess;
+  my $code = sub {
+    shift; 
+    print $_.$/ for(@_);
+  };
+
+  my $p = Mojo::IOLoop::ReadWriteProcess->new($code, args => '0' )->start->wait_stop();
+  is($p->read_all_stdout(), "0$/", '1) False scalar value was given as args.');
+
+  $p = Mojo::IOLoop::ReadWriteProcess->new($code)->args('0')->start->wait_stop();
+  is($p->read_all_stdout(), "0$/", '2) False scalar value was given as args.');
+
+  $p = Mojo::IOLoop::ReadWriteProcess->new($code, args => [(0..3)] )->start->wait_stop();
+  is($p->read_all_stdout(), "0$/1$/2$/3$/", '1) Args given as arrayref.');
+
+  $p = Mojo::IOLoop::ReadWriteProcess->new($code)->args([(0..3)])->start->wait_stop();
+  is($p->read_all_stdout(), "0$/1$/2$/3$/", '2) Args given as arrayref.');
+};
+
 done_testing;


### PR DESCRIPTION
### Fix `args` documentation
###  Fix `args` processing of false value
If `args` is given as scalar and the content is a false value, it was never given to the process as arguments.
### Add tests for `args` processing.
