### PR TITLE
Fix race on `open3/fork` and `session->register($pid)` call -- second attempt

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -121,6 +121,7 @@ sub _open {
   $self->_diag('Execute: ' . (join ', ', map { "'$_'" } @args)) if DEBUG;
 
   $self->session->enable;
+  $self->on(collect_status => \&_open_collect_status);
 
   my ($wtr, $rdr, $err);
   $err = gensym;
@@ -130,7 +131,6 @@ sub _open {
   $self->process_id($pid);
 
   # Defered collect of return status and removal of pidfile
-  $self->on(collect_status => \&_open_collect_status);
 
   return $self unless $self->set_pipes();
 

--- a/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
@@ -133,7 +133,7 @@ sub contains {
   $singleton->all->grep(sub { $_->pid eq $pid })->size == 1;
 }
 
-sub reset { @{+shift}{qw(events orphans process_table collected_info)} = ({}, {}, {}, []) }
+sub reset { @{+shift}{qw(events orphans process_table collected_info handler)} = ({}, {}, {}, [], undef) }
 
 # XXX: This should be replaced by PR_GET_CHILD_SUBREAPER
 sub disable_subreaper {

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -567,4 +567,15 @@ subtest 'process_args' => sub {
   is($p->read_all_stdout(), "0$/1$/2$/3$/", '2) Args given as arrayref.');
 };
 
+subtest 'process in process' => sub {
+    my $p = process(sub {
+        is( process(execute => '/usr/bin/true')->quirkiness(1)->start()->wait_stop()->exit_status(), 0, 'process(execute) from process(code) -- retval check true');
+        is( process(execute => '/usr/bin/false')->quirkiness(1)->start()->wait_stop()->exit_status(), 1, 'process(execute) from process(code) -- retval check false');
+        is( process(sub { print 'sub-sub-process'})->start()->wait_stop()->read_all_stdout, 'sub-sub-process', 'process(code) works from process(code)');
+        print 'DONE';
+    })->start()->wait_stop();
+
+    is ($p->read_all_stdout(), 'DONE', "Use ReadWriteProcess inside of ReadWriteProcess(code=>'')");
+};
+
 done_testing;

--- a/t/01_run.t
+++ b/t/01_run.t
@@ -301,6 +301,13 @@ subtest 'process execute()' => sub {
   $p->stop();
 };
 
+subtest 'process(execute =>"/usr/bin/true")' => sub {
+  use Mojo::IOLoop::ReadWriteProcess qw(process);
+  plan skip_all => "Missing '/usr/bin/true'" unless -e '/usr/bin/true';
+
+  is(process(execute => '/usr/bin/true')->quirkiness(1)->start()->wait_stop()->exit_status(), 0, 'Simple exec of "/usr/bin/true" return 0');
+};
+
 subtest 'process code()' => sub {
   use Mojo::IOLoop::ReadWriteProcess;
   use IO::Select;


### PR DESCRIPTION
This is a second option to fix this issue, see https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/pull/21. 
I would like to discuss what way fit's more.

The disadvantage of this process is, that we change the SIGMASK and the child will inherit it. 
But we only care of SIG_CHLD and this is reset in `fork()` path anyway.