### PR TITLE
Queue: add missing Time::HiRes

### DIFF
--- a/t/04_queues.t
+++ b/t/04_queues.t
@@ -5,6 +5,7 @@ use strict;
 use Test::More;
 use POSIX;
 use FindBin;
+use Time::HiRes 'sleep';
 use Mojo::File qw(tempfile path);
 use lib ("$FindBin::Bin/lib", "../lib", "lib");
 


### PR DESCRIPTION
In the consume method, we use a `sleep .5`, which is equal to `sleep 0`
if we miss Time::HiRes.
I think it wasn't the intention, so including Time::HiRes might help?!

see: https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/blob/master/lib/Mojo/IOLoop/ReadWriteProcess/Queue.pm#L30