### PR TITLE
Fix emitting `collected` event without extra polling for `is_running`

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -148,7 +148,6 @@ sub _collect {
   my ($self, $pid) = @_;
   $pid //= $self->pid;
 
-  $self->session->consume_collected_info;
   $self->session->_protect(
     sub {
       local $?;
@@ -247,7 +246,6 @@ sub _fork {
   }
 
   # Defered collect of return status
-
   $self->on(collect_status => \&_fork_collect_status);
 
   $self->_diag("Fork: " . $self->_deparse->coderef2text($code)) if DEBUG;
@@ -398,7 +396,6 @@ sub restart {
 }
 sub is_running {
     my ($self) = shift;
-    $self->session->consume_collected_info;
     $self->process_id ? kill 0 => $self->process_id : 0;
 }
 
@@ -477,18 +474,15 @@ sub start {
   $self->_status(undef);
   $self->session->enable;
 
-
   if ($self->code) {
     $self->_fork($self->code, @args);
   }
   elsif ($self->execute) {
     $self->_open($self->execute, @args);
   }
-
   $self->write_pidfile;
   $self->emit('start');
   $self->session->register($self->pid() => $self);
-
   return $self;
 }
 

--- a/lib/Mojo/IOLoop/ReadWriteProcess/Queue.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/Queue.pm
@@ -28,7 +28,6 @@ sub consume {
     $self->queue->maximum_processes + $self->pool->maximum_processes);
   until ($self->exhausted) {
     sleep .5;
-    $self->session->consume_collected_info;
     $self->session->_protect(
       sub {
         $self->pool->each(


### PR DESCRIPTION
Alternative: #32

---

* Fix issues in os-autoint's tests and openQA's worker
    * https://progress.opensuse.org/issues/103605
    * https://progress.opensuse.org/issues/103611
    * https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/issues/29
* Emit the event from the SIGCHLD handler again
* Ignore unknown process IDs in SIGCHLD handler to avoid the race condition
  1e0addb was fixing
* Has the caveat that `orphans` will no longer be populated