### PR TITLE
Fix emitting `collected` event without extra polling for `is_running`

### DIFF
--- a/lib/Mojo/IOLoop/ReadWriteProcess.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess.pm
@@ -148,7 +148,6 @@ sub _collect {
   my ($self, $pid) = @_;
   $pid //= $self->pid;
 
-  $self->session->consume_collected_info;
   $self->session->_protect(
     sub {
       local $?;
@@ -247,7 +246,6 @@ sub _fork {
   }
 
   # Defered collect of return status
-
   $self->on(collect_status => \&_fork_collect_status);
 
   $self->_diag("Fork: " . $self->_deparse->coderef2text($code)) if DEBUG;
@@ -256,6 +254,11 @@ sub _fork {
   die "Cannot fork: $!" unless defined $pid;
 
   if ($pid == 0) {
+    # unnblock SIGCHLD
+    # note: It is blocked by the parent process to avoid a race condition. The forked process inherits
+    #       that so the signal must be unblocked here again.
+    sigprocmask(SIG_UNBLOCK, POSIX::SigSet->new(SIGCHLD));
+
     local $SIG{CHLD};
     local $SIG{TERM} = sub { $self->emit('SIG_TERM')->_exit(1) };
 
@@ -398,7 +401,6 @@ sub restart {
 }
 sub is_running {
     my ($self) = shift;
-    $self->session->consume_collected_info;
     $self->process_id ? kill 0 => $self->process_id : 0;
 }
 
@@ -477,18 +479,17 @@ sub start {
   $self->_status(undef);
   $self->session->enable;
 
-
-  if ($self->code) {
-    $self->_fork($self->code, @args);
-  }
-  elsif ($self->execute) {
-    $self->_open($self->execute, @args);
-  }
-
-  $self->write_pidfile;
-  $self->emit('start');
-  $self->session->register($self->pid() => $self);
-
+  $self->session->_protect(sub {
+    if ($self->code) {
+      $self->_fork($self->code, @args);
+    }
+    elsif ($self->execute) {
+      $self->_open($self->execute, @args);
+    }
+    $self->write_pidfile;
+    $self->emit('start');
+    $self->session->register($self->pid() => $self);
+  });
   return $self;
 }
 

--- a/lib/Mojo/IOLoop/ReadWriteProcess/Queue.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/Queue.pm
@@ -28,7 +28,6 @@ sub consume {
     $self->queue->maximum_processes + $self->pool->maximum_processes);
   until ($self->exhausted) {
     sleep .5;
-    $self->session->consume_collected_info;
     $self->session->_protect(
       sub {
         $self->pool->each(

--- a/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
+++ b/lib/Mojo/IOLoop/ReadWriteProcess/Session.pm
@@ -21,7 +21,6 @@ has subreaper      => 0;
 has collect_status => 1;
 has orphans        => sub { {} };
 has process_table  => sub { {} };
-has collected_info => sub { [] };
 has 'handler';
 
 my $singleton;
@@ -44,8 +43,7 @@ sub _protect {
 }
 
 sub enable {
-  return if $singleton->handler();
-  $singleton->handler($SIG{CHLD});
+  $singleton->handler($SIG{CHLD}) unless $singleton->handler;
   $singleton->_protect(
     sub {
       $SIG{CHLD} = sub {
@@ -53,7 +51,7 @@ sub enable {
         $singleton->emit('SIG_CHLD');
         return unless $singleton->collect_status;
         while ((my $pid = waitpid(-1, WNOHANG)) > 0) {
-          $singleton->add_collected_info($pid, $?, $!);
+          $singleton->collect($pid => $? => $!);
         }
       }
     });
@@ -79,17 +77,6 @@ sub collect {
     $singleton->emit(collected_orphan => $singleton->orphan($pid));
   }
   return $singleton;
-}
-
-sub consume_collected_info {
-    while(my $i = shift @{$singleton->collected_info}) {
-        $singleton->collect(@$i) 
-    }
-}
-
-sub add_collected_info {
-    shift;
-    push @{$singleton->collected_info}, [@_];
 }
 
 # Use as $pid => Mojo::IOLoop::ReadWriteProcess
@@ -133,7 +120,7 @@ sub contains {
   $singleton->all->grep(sub { $_->pid eq $pid })->size == 1;
 }
 
-sub reset { @{+shift}{qw(events orphans process_table collected_info handler)} = ({}, {}, {}, [], undef) }
+sub reset { @{+shift}{qw(events orphans process_table handler)} = ({}, {}, {}, [], undef) }
 
 # XXX: This should be replaced by PR_GET_CHILD_SUBREAPER
 sub disable_subreaper {


### PR DESCRIPTION
Alternative: #31

---

* Fix issues in os-autoint's tests and openQA's worker
    * https://progress.opensuse.org/issues/103605
    * https://progress.opensuse.org/issues/103611
    * https://github.com/mudler/Mojo-IOLoop-ReadWriteProcess/issues/29
* Emit the event from the SIGCHLD handler again
* Block `SIGCHLD` to avoid when spawning the sub process to still avoid the
  race condition 1e0addb was fixing
* Has the disadvantage that `SIGCHLD` is also blocked in sub processes
  which might not expect that (e.g. when spawning sub processes on their
  own and also trying to handle `SIGCHLD`)